### PR TITLE
I2C Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ nosetests.xml
 *.log
 *.aux
 docs/*.pdf
+
+# Python
+VIRTUAL/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install:
     - pip install flake8
 script:
-    - flake8 --max-line-length=99 --ignore=E126,E127,E128,C901 RPLCD/lcd.py
+    - flake8 --max-line-length=99 --ignore=E126,E127,E128,C901 RPLCD/[a-zA-Z]*.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Possible log types:
 - `[fix]` for any bug fixes.
 - `[sec]` to invite users to upgrade in case of vulnerabilities.
 
+### v0.5.0 UNRELEASED
+
+- [add] Support for i2c (#20)
+
 ### v0.4.0 (2016-09-12)
 
 - [fix] Fix problem when auto-linebreaks clash with manual linebreaks (#14)

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,8 @@ RPLCD
     :alt: License
 
 A Python 2/3 Raspberry PI Character LCD library for the Hitachi HD44780
-controller.
+controller. It supports both GPIO (parallel) mode as well as boards with an I2C
+port expander (e.g. the PCF8574).
 
 Tested with the 20x4 LCD that is sold for example by `adafruit.com
 <http://www.adafruit.com/products/198>`_ or `mikroshop.ch

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,17 @@ Arduino's LiquidCrystal_ library.
 No external dependencies (except the RPi.GPIO library, which comes preinstalled
 on Raspbian) are needed to use this library.
 
+Setup
+=====
 
+Install this library using pip::
+
+    pip install RPLCD
+
+If you want to use I2C, you also need smbus::
+
+    sudo apt install python-smbus
+￼
 Features
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Basic text output with multiline control.
 
 .. sourcecode:: python
 
-    >>> from RPLCD import CharLCD
+    >>> from RPLCD.gpio import CharLCD
     >>> lcd = CharLCD()
     >>> lcd.write_string(u'Raspberry Pi HD44780')
     >>> lcd.cursor_pos = (2, 0)
@@ -147,7 +147,7 @@ ends.
 
 .. sourcecode:: python
 
-    >>> from RPLCD import CharLCD, cleared, cursor
+    >>> from RPLCD.gpio import CharLCD, cleared, cursor
     >>> lcd = CharLCD()
     >>>
     >>> with cleared(lcd):
@@ -168,7 +168,7 @@ function in combination with the location number you specified previously (e.g.
 
 .. sourcecode:: python
 
-    >>> from RPLCD import CharLCD, cleared, cursor
+    >>> from RPLCD.gpio import CharLCD, cleared, cursor
     >>> lcd = CharLCD()
     >>>
     >>> smiley = (
@@ -225,7 +225,7 @@ Init, Setup, Teardown
 .. sourcecode:: python
 
     import RPi.GPIO as GPIO
-    from RPLCD import CharLCD, BacklightMode
+    from RPLCD.gpio import CharLCD, BacklightMode
 
     # Initialize display. All values have default values and are therefore
     # optional.

--- a/RPLCD/__init__.py
+++ b/RPLCD/__init__.py
@@ -1,2 +1,11 @@
+import warnings
+
 from .common import Alignment, CursorMode, ShiftMode, BacklightMode
 from .contextmanagers import cursor, cleared
+from .gpio import CharLCD as GpioCharLCD
+
+class CharLCD(GpioCharLCD):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("Using RPLCD.CharLCD directly is deprecated. " +
+                      "Use RPLCD.gpio.CharLCD instead!", DeprecationWarning)
+        super(CharLCD, self).__init__(*args, **kwargs)

--- a/RPLCD/__init__.py
+++ b/RPLCD/__init__.py
@@ -1,5 +1,2 @@
-from .lcd import CharLCD
-from .lcd import Alignment, CursorMode, ShiftMode
+from .common import Alignment, CursorMode, ShiftMode, BacklightMode
 from .contextmanagers import cursor, cleared
-from .lcd import BacklightMode
-

--- a/RPLCD/common.py
+++ b/RPLCD/common.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (C) 2013-2016 Danilo Bargen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import time
+
+from . import enum
+
+
+# # # BIT PATTERNS # # #
+
+# Commands
+LCD_CLEARDISPLAY = 0x01
+LCD_RETURNHOME = 0x02
+LCD_ENTRYMODESET = 0x04
+LCD_DISPLAYCONTROL = 0x08
+LCD_CURSORSHIFT = 0x10
+LCD_FUNCTIONSET = 0x20
+LCD_SETCGRAMADDR = 0x40
+LCD_SETDDRAMADDR = 0x80
+
+# Flags for display entry mode
+LCD_ENTRYRIGHT = 0x00
+LCD_ENTRYLEFT = 0x02
+LCD_ENTRYSHIFTINCREMENT = 0x01
+LCD_ENTRYSHIFTDECREMENT = 0x00
+
+# Flags for display on/off control
+LCD_DISPLAYON = 0x04
+LCD_DISPLAYOFF = 0x00
+LCD_CURSORON = 0x02
+LCD_CURSOROFF = 0x00
+LCD_BLINKON = 0x01
+LCD_BLINKOFF = 0x00
+
+# Flags for display/cursor shift
+LCD_DISPLAYMOVE = 0x08
+LCD_CURSORMOVE = 0x00
+
+# Flags for display/cursor shift
+LCD_DISPLAYMOVE = 0x08
+LCD_CURSORMOVE = 0x00
+LCD_MOVERIGHT = 0x04
+LCD_MOVELEFT = 0x00
+
+# Flags for function set
+LCD_8BITMODE = 0x10
+LCD_4BITMODE = 0x00
+LCD_2LINE = 0x08
+LCD_1LINE = 0x00
+LCD_5x10DOTS = 0x04
+LCD_5x8DOTS = 0x00
+
+# Flags for backlight control
+LCD_BACKLIGHT = 0x08
+LCD_NOBACKLIGHT = 0x00
+
+# Flags for RS pin modes
+RS_INSTRUCTION = 0x00
+RS_DATA = 0x01
+
+# Pin bitmasks
+PIN_ENABLE = 0x4
+PIN_READ_WRITE = 0x2
+PIN_REGISTER_SELECT = 0x1
+
+
+# # # ENUMS # # #
+
+class Alignment(enum.Enum):
+    left = LCD_ENTRYLEFT
+    right = LCD_ENTRYRIGHT
+
+
+class ShiftMode(enum.Enum):
+    cursor = LCD_ENTRYSHIFTDECREMENT
+    display = LCD_ENTRYSHIFTINCREMENT
+
+
+class CursorMode(enum.Enum):
+    hide = LCD_CURSOROFF | LCD_BLINKOFF
+    line = LCD_CURSORON | LCD_BLINKOFF
+    blink = LCD_CURSOROFF | LCD_BLINKON
+
+
+class BacklightMode(enum.Enum):
+    active_high = 1
+    active_low = 2
+
+
+# # # HELPER FUNCTIONS # # #
+
+def msleep(milliseconds):
+    """Sleep the specified amount of milliseconds."""
+    time.sleep(milliseconds / 1000.0)
+
+
+def usleep(microseconds):
+    """Sleep the specified amount of microseconds."""
+    time.sleep(microseconds / 1000000.0)

--- a/RPLCD/compat.py
+++ b/RPLCD/compat.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+"""
 Copyright (C) 2013-2016 Danilo Bargen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -16,3 +18,14 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+
+# # # PYTHON 3 COMPAT # # #
+
+try:
+    range = xrange
+except NameError:
+    range = range

--- a/RPLCD/enum.py
+++ b/RPLCD/enum.py
@@ -263,7 +263,7 @@ IntEnum = IntEnumMetaclass(str('IntEnum'), (Enum,), {
 
 if str is bytes:
     # Python 2
-    STRING_TYPE = basestring
+    STRING_TYPE = basestring  # noqa: F821
 else:
     # Python 3
     STRING_TYPE = str

--- a/RPLCD/enum.py
+++ b/RPLCD/enum.py
@@ -219,7 +219,7 @@ class EnumValue:
 # and Python 3.
 Enum = EnumMetaclass(str('Enum'), (), {
     '__doc__': 'The public API Enum class.',
-    })
+})
 
 
 class IntEnumValue(int, EnumValue):
@@ -258,7 +258,7 @@ class IntEnumMetaclass(EnumMetaclass):
 IntEnum = IntEnumMetaclass(str('IntEnum'), (Enum,), {
     '__doc__': 'A specialized enumeration with values that are also integers.',
     '__value_factory__': IntEnumValue,
-    })
+})
 
 
 if str is bytes:

--- a/RPLCD/gpio.py
+++ b/RPLCD/gpio.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (C) 2013-2016 Danilo Bargen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from collections import namedtuple
+
+import RPi.GPIO as GPIO
+
+from . import common as c
+from .lcd import BaseCharLCD
+from .compat import range
+
+
+PinConfig = namedtuple('PinConfig', 'rs rw e d0 d1 d2 d3 d4 d5 d6 d7 backlight mode')
+
+
+class CharLCD(BaseCharLCD):
+    def __init__(self, pin_rs=15, pin_rw=18, pin_e=16, pins_data=[21, 22, 23, 24],
+                       pin_backlight=None, backlight_mode=c.BacklightMode.active_low,
+                       backlight_enabled=True,
+                       numbering_mode=GPIO.BOARD,
+                       cols=20, rows=4, dotsize=8,
+                       auto_linebreaks=True):
+        """
+        Character LCD controller.
+
+        The default pin numbers are based on the BOARD numbering scheme (1-26).
+
+        You can save 1 pin by not using RW. Set ``pin_rw`` to ``None`` if you
+        want this.
+
+        Args:
+            pin_rs:
+                Pin for register select (RS). Default: 15.
+            pin_rw:
+                Pin for selecting read or write mode (R/W). Set this to
+                ``None`` for read only mode. Default: 18.
+            pin_e:
+                Pin to start data read or write (E). Default: 16.
+            pins_data:
+                List of data bus pins in 8 bit mode (DB0-DB7) or in 4 bit mode
+                (DB4-DB7) in ascending order. Default: [21, 22, 23, 24].
+            pin_backlight:
+                Pin for controlling backlight on/off. Set this to ``None`` for
+                no backlight control. Default: None.
+            backlight_mode:
+                Set this to one of the BacklightMode enum values to configure the
+                operating control for the backlight. Has no effect if pin_backlight is ``None``
+            backlight_enabled:
+                Set this to True to turn on the backlight or False to turn it off.
+                Has no effect if pin_backlight is ``None``
+            numbering_mode:
+                Which scheme to use for numbering of the GPIO pins, either
+                ``GPIO.BOARD`` or ``GPIO.BCM``.  Default: ``GPIO.BOARD`` (1-26).
+            rows:
+                Number of display rows (usually 1, 2 or 4). Default: 4.
+            cols:
+                Number of columns per row (usually 16 or 20). Default 20.
+            dotsize:
+                Some 1 line displays allow a font height of 10px.
+                Allowed: 8 or 10. Default: 8.
+            auto_linebreaks:
+                Whether or not to automatically insert line breaks.
+                Default: True.
+
+        Returns:
+            A :class:`CharLCD` instance.
+
+        """
+        # Set attributes
+        self.numbering_mode = numbering_mode
+        if len(pins_data) == 4:  # 4 bit mode
+            self.data_bus_mode = c.LCD_4BITMODE
+            block1 = [None] * 4
+        elif len(pins_data) == 8:  # 8 bit mode
+            self.data_bus_mode = c.LCD_8BITMODE
+            block1 = pins_data[:4]
+        else:
+            raise ValueError('There should be exactly 4 or 8 data pins.')
+        block2 = pins_data[-4:]
+        self.pins = PinConfig(rs=pin_rs, rw=pin_rw, e=pin_e,
+                              d0=block1[0], d1=block1[1], d2=block1[2], d3=block1[3],
+                              d4=block2[0], d5=block2[1], d6=block2[2], d7=block2[3],
+                              backlight=pin_backlight,
+                              mode=numbering_mode)
+        self.backlight_mode = backlight_mode
+
+        # Call superclass
+        super(CharLCD, self).__init__(cols, rows, dotsize, auto_linebreaks)
+
+    def _init_connection(self):
+        # Setup GPIO
+        GPIO.setmode(self.numbering_mode)
+        for pin in list(filter(None, self.pins))[:-1]:
+            GPIO.setup(pin, GPIO.OUT)
+        if self.pins.backlight is not None:
+            GPIO.setup(self.pins.backlight, GPIO.OUT)
+            # must enable the backlight AFTER setting up GPIO
+            # TODO
+            #self.backlight_enabled = backlight_enabled
+
+        # Initialization
+        c.msleep(50)
+        GPIO.output(self.pins.rs, 0)
+        GPIO.output(self.pins.e, 0)
+        if self.pins.rw is not None:
+            GPIO.output(self.pins.rw, 0)
+
+    def _close_connection(self):
+        GPIO.cleanup()
+
+    # Low level commands
+
+    def _send(self, value, mode):
+        """Send the specified value to the display with automatic 4bit / 8bit
+        selection. The rs_mode is either ``RS_DATA`` or ``RS_INSTRUCTION``."""
+
+        # Choose instruction or data mode
+        GPIO.output(self.pins.rs, mode)
+
+        # If the RW pin is used, set it to low in order to write.
+        if self.pins.rw is not None:
+            GPIO.output(self.pins.rw, 0)
+
+        # Write data out in chunks of 4 or 8 bit
+        if self.data_bus_mode == c.LCD_8BITMODE:
+            self._write8bits(value)
+        else:
+            self._write4bits(value >> 4)
+            self._write4bits(value)
+
+    def _write4bits(self, value):
+        """Write 4 bits of data into the data bus."""
+        for i in range(4):
+            bit = (value >> i) & 0x01
+            GPIO.output(self.pins[i + 7], bit)
+        self._pulse_enable()
+
+    def _write8bits(self, value):
+        """Write 8 bits of data into the data bus."""
+        for i in range(8):
+            bit = (value >> i) & 0x01
+            GPIO.output(self.pins[i + 3], bit)
+        self._pulse_enable()
+
+    def _pulse_enable(self):
+        """Pulse the `enable` flag to process data."""
+        GPIO.output(self.pins.e, 0)
+        c.usleep(1)
+        GPIO.output(self.pins.e, 1)
+        c.usleep(1)
+        GPIO.output(self.pins.e, 0)
+        c.usleep(100)  # commands need > 37us to settle

--- a/RPLCD/gpio.py
+++ b/RPLCD/gpio.py
@@ -145,7 +145,8 @@ class CharLCD(BaseCharLCD):
         if not isinstance(value, bool):
             raise ValueError('backlight_enabled must be set to ``True`` or ``False``.')
         self._backlight_enabled = value
-        GPIO.output(self.pins.backlight, value ^ (self.backlight_mode is c.BacklightMode.active_low))
+        GPIO.output(self.pins.backlight,
+                    value ^ (self.backlight_mode is c.BacklightMode.active_low))
 
     backlight_enabled = property(_get_backlight_enabled, _set_backlight_enabled,
             doc='Whether or not to turn on the backlight.')

--- a/RPLCD/i2c.py
+++ b/RPLCD/i2c.py
@@ -37,16 +37,44 @@ class CharLCD(BaseCharLCD):
         D7 | D6 | D5 | D4 | BL | EN | RW | RS
 
     """
-    def __init__(self, address, port=1, cols=20, rows=4, dotsize=8):
+    def __init__(self, address, port=1, cols=20, rows=4, dotsize=8, backlight_enabled=True):
+        """
+        Character LCD controller.
+
+        Args:
+            address:
+                The I2C address of your LCD.
+            port:
+                The I2C port number. Default: 1.
+            cols:
+                Number of columns per row (usually 16 or 20). Default: 20.
+            rows:
+                Number of display rows (usually 1, 2 or 4). Default: 4.
+            dotsize:
+                Some 1 line displays allow a font height of 10px.
+                Allowed: 8 or 10. Default: 8.
+            backlight_enabled:
+                Whether the backlight is enabled initially. Default: True.
+
+        Returns:
+            A :class:`CharLCD` instance.
+
+        """
+        # Set own address and port.
         self.address = address
         self.port = port
-        self._backlight = c.LCD_BACKLIGHT
 
         # Currently the I2C mode only supports 4 bit communication
         self.data_bus_mode = c.LCD_4BITMODE
 
+        # Set backlight status
+        self._backlight = c.LCD_BACKLIGHT if backlight_enabled else c.LCD_NOBACKLIGHT
+
         # Call superclass
         super(CharLCD, self).__init__(cols, rows, dotsize)
+
+        # Refresh backlight status
+        self.backlight_enabled = backlight_enabled
 
     def _init_connection(self):
         print('init connection')
@@ -56,7 +84,7 @@ class CharLCD(BaseCharLCD):
     def _close_connection(self):
         print('close connection')
 
-    # High level commands
+    # Properties
 
     def _get_backlight_enabled(self):
         return self._backlight == c.LCD_BACKLIGHT

--- a/RPLCD/i2c.py
+++ b/RPLCD/i2c.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (C) 2013-2016 Danilo Bargen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from smbus import SMBus
+
+from . import common as c
+from .lcd import BaseCharLCD
+
+
+class CharLCD(BaseCharLCD):
+    """CharLCD via PCF8574 I2C port expander.
+
+    Pin mapping::
+
+        7  | 6  | 5  | 4  | 3  | 2  | 1  | 0
+        D7 | D6 | D5 | D4 | BL | EN | RW | RS
+
+    """
+    def __init__(self, address, port=1, cols=20, rows=4, dotsize=8):
+        self.address = address
+        self.port = port
+        self._backlight = c.LCD_BACKLIGHT
+
+        # Currently the I2C mode only supports 4 bit communication
+        self.data_bus_mode = c.LCD_4BITMODE
+
+        # Call superclass
+        super(CharLCD, self).__init__(cols, rows, dotsize)
+
+    def _init_connection(self):
+        print('init connection')
+        self.bus = SMBus(self.port)
+        c.msleep(50)
+
+    def _close_connection(self):
+        print('close connection')
+
+    # High level commands
+
+    def _get_backlight_enabled(self):
+        return self._backlight == c.LCD_BACKLIGHT
+
+    def _set_backlight_enabled(self, value):
+        self._backlight = c.LCD_BACKLIGHT if value else c.LCD_NOBACKLIGHT
+        self.bus.write_byte(self.address, self._backlight)
+
+    backlight_enabled = property(_get_backlight_enabled, _set_backlight_enabled,
+            doc='Whether or not to enable the backlight.')
+
+    # Low level commands
+
+    def _send(self, value, mode):
+        """Send the specified value to the display with automatic 4bit / 8bit selection.
+        The rs_mode is either ``common.RS_DATA`` or ``common.RS_INSTRUCTION``."""
+        self._write4bits(mode | (value & 0xF0))
+        self._write4bits(mode | ((value << 4) & 0xF0))
+
+    def _write4bits(self, value):
+        """Write 4 bits of data into the data bus."""
+        self.bus.write_byte(self.address, value | self._backlight)
+        self._pulse_data(value)
+
+    def _write8bits(self, value):
+        """Write 8 bits of data into the data bus."""
+        raise NotImplementedError('I2C currently supports only 4bit.')
+
+    def _pulse_data(self, value):
+        """Pulse the `enable` flag to process value."""
+        self.bus.write_byte(self.address, ((value & ~c.PIN_ENABLE) | self._backlight))
+        c.usleep(1)
+        self.bus.write_byte(self.address, value | c.PIN_ENABLE | self._backlight)
+        c.usleep(1)
+        self.bus.write_byte(self.address, ((value & ~c.PIN_ENABLE) | self._backlight))
+        c.usleep(100)

--- a/RPLCD/lcd.py
+++ b/RPLCD/lcd.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2013-2015 Danilo Bargen
+Copyright (C) 2013-2016 Danilo Bargen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -22,155 +22,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-import time
 from collections import namedtuple
 
 import RPi.GPIO as GPIO
 
-from . import enum
+from . import common as c
+from .compat import range
 
 
-# # # PYTHON 3 COMPAT # # #
-
-try:
-    range = xrange
-except NameError:
-    pass
-
-
-# # # BIT PATTERNS # # #
-
-# Commands
-LCD_CLEARDISPLAY = 0x01
-LCD_RETURNHOME = 0x02
-LCD_ENTRYMODESET = 0x04
-LCD_DISPLAYCONTROL = 0x08
-LCD_CURSORSHIFT = 0x10
-LCD_FUNCTIONSET = 0x20
-LCD_SETCGRAMADDR = 0x40
-LCD_SETDDRAMADDR = 0x80
-
-# Flags for display entry mode
-LCD_ENTRYRIGHT = 0x00
-LCD_ENTRYLEFT = 0x02
-LCD_ENTRYSHIFTINCREMENT = 0x01
-LCD_ENTRYSHIFTDECREMENT = 0x00
-
-# Flags for display on/off control
-LCD_DISPLAYON = 0x04
-LCD_DISPLAYOFF = 0x00
-LCD_CURSORON = 0x02
-LCD_CURSOROFF = 0x00
-LCD_BLINKON = 0x01
-LCD_BLINKOFF = 0x00
-
-# Flags for display/cursor shift
-LCD_DISPLAYMOVE = 0x08
-LCD_CURSORMOVE = 0x00
-
-# Flags for display/cursor shift
-LCD_DISPLAYMOVE = 0x08
-LCD_CURSORMOVE = 0x00
-LCD_MOVERIGHT = 0x04
-LCD_MOVELEFT = 0x00
-
-# Flags for function set
-LCD_8BITMODE = 0x10
-LCD_4BITMODE = 0x00
-LCD_2LINE = 0x08
-LCD_1LINE = 0x00
-LCD_5x10DOTS = 0x04
-LCD_5x8DOTS = 0x00
-
-# Flags for RS pin modes
-RS_INSTRUCTION = 0x00
-RS_DATA = 0x01
-
-
-# # # NAMEDTUPLES # # #
-
-PinConfig = namedtuple('PinConfig', 'rs rw e d0 d1 d2 d3 d4 d5 d6 d7 backlight mode')
 LCDConfig = namedtuple('LCDConfig', 'rows cols dotsize')
-
-
-# # # ENUMS # # #
-
-class Alignment(enum.Enum):
-    left = LCD_ENTRYLEFT
-    right = LCD_ENTRYRIGHT
-
-
-class ShiftMode(enum.Enum):
-    cursor = LCD_ENTRYSHIFTDECREMENT
-    display = LCD_ENTRYSHIFTINCREMENT
-
-
-class CursorMode(enum.Enum):
-    hide = LCD_CURSOROFF | LCD_BLINKOFF
-    line = LCD_CURSORON | LCD_BLINKOFF
-    blink = LCD_CURSOROFF | LCD_BLINKON
-
-
-class BacklightMode(enum.Enum):
-    active_high = 1
-    active_low = 2
-
-
-# # # HELPER FUNCTIONS # # #
-
-def msleep(milliseconds):
-    """Sleep the specified amount of milliseconds."""
-    time.sleep(milliseconds / 1000.0)
-
-
-def usleep(microseconds):
-    """Sleep the specified amount of microseconds."""
-    time.sleep(microseconds / 1000000.0)
 
 
 # # # MAIN # # #
 
-class CharLCD(object):
+class BaseCharLCD(object):
 
     # Init, setup, teardown
 
-    def __init__(self, pin_rs=15, pin_rw=18, pin_e=16, pins_data=[21, 22, 23, 24],
-                       pin_backlight=None, backlight_mode=BacklightMode.active_low,
-                       backlight_enabled=True,
-                       numbering_mode=GPIO.BOARD,
-                       cols=20, rows=4, dotsize=8,
-                       auto_linebreaks=True):
+    def __init__(self, cols=20, rows=4, dotsize=8, auto_linebreaks=True):
         """
-        Character LCD controller.
-
-        The default pin numbers are based on the BOARD numbering scheme (1-26).
-
-        You can save 1 pin by not using RW. Set ``pin_rw`` to ``None`` if you
-        want this.
+        Character LCD controller. Base class only, you should use a subclass.
 
         Args:
-            pin_rs:
-                Pin for register select (RS). Default: 15.
-            pin_rw:
-                Pin for selecting read or write mode (R/W). Set this to
-                ``None`` for read only mode. Default: 18.
-            pin_e:
-                Pin to start data read or write (E). Default: 16.
-            pins_data:
-                List of data bus pins in 8 bit mode (DB0-DB7) or in 4 bit mode
-                (DB4-DB7) in ascending order. Default: [21, 22, 23, 24].
-            pin_backlight:
-                Pin for controlling backlight on/off. Set this to ``None`` for
-                no backlight control. Default: None.
-            backlight_mode:
-                Set this to one of the BacklightMode enum values to configure the
-                operating control for the backlight. Has no effect if pin_backlight is ``None``
-            backlight_enabled:
-                Set this to True to turn on the backlight or False to turn it off.
-                Has no effect if pin_backlight is ``None``
-            numbering_mode:
-                Which scheme to use for numbering of the GPIO pins, either
-                ``GPIO.BOARD`` or ``GPIO.BCM``.  Default: ``GPIO.BOARD`` (1-26).
             rows:
                 Number of display rows (usually 1, 2 or 4). Default: 4.
             cols:
@@ -182,50 +55,22 @@ class CharLCD(object):
                 Whether or not to automatically insert line breaks.
                 Default: True.
 
-        Returns:
-            A :class:`CharLCD` instance.
-
         """
         assert dotsize in [8, 10], 'The ``dotsize`` argument should be either 8 or 10.'
 
-        # Set attributes
-        self.numbering_mode = numbering_mode
-        if len(pins_data) == 4:  # 4 bit mode
-            self.data_bus_mode = LCD_4BITMODE
-            block1 = [None] * 4
-        elif len(pins_data) == 8:  # 8 bit mode
-            self.data_bus_mode = LCD_8BITMODE
-            block1 = pins_data[:4]
-        else:
-            raise ValueError('There should be exactly 4 or 8 data pins.')
-        block2 = pins_data[-4:]
-        self.pins = PinConfig(rs=pin_rs, rw=pin_rw, e=pin_e,
-                              d0=block1[0], d1=block1[1], d2=block1[2], d3=block1[3],
-                              d4=block2[0], d5=block2[1], d6=block2[2], d7=block2[3],
-                              backlight=pin_backlight,
-                              mode=numbering_mode)
-        self.backlight_mode = backlight_mode
+        # LCD configuration
         self.lcd = LCDConfig(rows=rows, cols=cols, dotsize=dotsize)
 
-        # Setup GPIO
-        GPIO.setmode(self.numbering_mode)
-        for pin in list(filter(None, self.pins))[:-1]:
-            GPIO.setup(pin, GPIO.OUT)
-        if pin_backlight is not None:
-            GPIO.setup(pin_backlight, GPIO.OUT)
-            # must enable the backlight AFTER setting up GPIO
-            self.backlight_enabled = backlight_enabled
-
         # Setup initial display configuration
-        displayfunction = self.data_bus_mode | LCD_5x8DOTS
+        displayfunction = self.data_bus_mode | c.LCD_5x8DOTS
         if rows == 1:
-            displayfunction |= LCD_1LINE
+            displayfunction |= c.LCD_1LINE
         elif rows in [2, 4]:
             # LCD only uses two lines on 4 row displays
-            displayfunction |= LCD_2LINE
+            displayfunction |= c.LCD_2LINE
         if dotsize == 10:
             # For some 1 line displays you can select a 10px font.
-            displayfunction |= LCD_5x10DOTS
+            displayfunction |= c.LCD_5x10DOTS
 
         # Create content cache
         self._content = [[0x20] * cols for _ in range(rows)]
@@ -234,57 +79,53 @@ class CharLCD(object):
         self.auto_linebreaks = auto_linebreaks
         self.recent_auto_linebreak = False
 
-        # Initialization
-        msleep(50)
-        GPIO.output(self.pins.rs, 0)
-        GPIO.output(self.pins.e, 0)
-        if self.pins.rw is not None:
-            GPIO.output(self.pins.rw, 0)
+        # Initialize display
+        self._init_connection()
 
         # Choose 4 or 8 bit mode
-        if self.data_bus_mode == LCD_4BITMODE:
+        if self.data_bus_mode == c.LCD_4BITMODE:
             # Hitachi manual page 46
-            self._write4bits(0x03)
-            msleep(4.5)
-            self._write4bits(0x03)
-            msleep(4.5)
-            self._write4bits(0x03)
-            usleep(100)
-            self._write4bits(0x02)
-        elif self.data_bus_mode == LCD_8BITMODE:
+            self.command(0x03)
+            c.msleep(4.5)
+            self.command(0x03)
+            c.msleep(4.5)
+            self.command(0x03)
+            c.usleep(100)
+            self.command(0x02)
+        elif self.data_bus_mode == c.LCD_8BITMODE:
             # Hitachi manual page 45
-            self._write8bits(0x30)
-            msleep(4.5)
-            self._write8bits(0x30)
-            usleep(100)
-            self._write8bits(0x30)
+            self.command(0x30)
+            c.msleep(4.5)
+            self.command(0x30)
+            c.usleep(100)
+            self.command(0x30)
         else:
             raise ValueError('Invalid data bus mode: {}'.format(self.data_bus_mode))
 
         # Write configuration to display
-        self.command(LCD_FUNCTIONSET | displayfunction)
-        usleep(50)
+        self.command(c.LCD_FUNCTIONSET | displayfunction)
+        c.usleep(50)
 
         # Configure display mode
-        self._display_mode = LCD_DISPLAYON
-        self._cursor_mode = int(CursorMode.hide)
-        self.command(LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
-        usleep(50)
+        self._display_mode = c.LCD_DISPLAYON
+        self._cursor_mode = int(c.CursorMode.hide)
+        self.command(c.LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
+        c.usleep(50)
 
         # Clear display
         self.clear()
 
         # Configure entry mode
-        self._text_align_mode = int(Alignment.left)
-        self._display_shift_mode = int(ShiftMode.cursor)
+        self._text_align_mode = int(c.Alignment.left)
+        self._display_shift_mode = int(c.ShiftMode.cursor)
         self._cursor_pos = (0, 0)
-        self.command(LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
-        usleep(50)
+        self.command(c.LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
+        c.usleep(50)
 
     def close(self, clear=False):
         if clear:
             self.clear()
-        GPIO.cleanup()
+        self._close_connection()
 
     # Properties
 
@@ -299,67 +140,67 @@ class CharLCD(object):
             raise ValueError(msg.format(pos=value, lcd=self.lcd))
         row_offsets = [0x00, 0x40, self.lcd.cols, 0x40 + self.lcd.cols]
         self._cursor_pos = value
-        self.command(LCD_SETDDRAMADDR | row_offsets[value[0]] + value[1])
-        usleep(50)
+        self.command(c.LCD_SETDDRAMADDR | row_offsets[value[0]] + value[1])
+        c.usleep(50)
 
     cursor_pos = property(_get_cursor_pos, _set_cursor_pos,
             doc='The cursor position as a 2-tuple (row, col).')
 
     def _get_text_align_mode(self):
         try:
-            return Alignment[self._text_align_mode]
+            return c.Alignment[self._text_align_mode]
         except ValueError:
             raise ValueError('Internal _text_align_mode has invalid value.')
 
     def _set_text_align_mode(self, value):
-        if value not in Alignment:
-            raise ValueError('Cursor move mode must be of ``Alignment`` type.')
+        if value not in c.Alignment:
+            raise ValueError('Cursor move mode must be of ``common.Alignment`` type.')
         self._text_align_mode = int(value)
-        self.command(LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
-        usleep(50)
+        self.command(c.LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
+        c.usleep(50)
 
     text_align_mode = property(_get_text_align_mode, _set_text_align_mode,
             doc='The text alignment (``Alignment.left`` or ``Alignment.right``).')
 
     def _get_write_shift_mode(self):
         try:
-            return ShiftMode[self._display_shift_mode]
+            return c.ShiftMode[self._display_shift_mode]
         except ValueError:
             raise ValueError('Internal _display_shift_mode has invalid value.')
 
     def _set_write_shift_mode(self, value):
-        if value not in ShiftMode:
-            raise ValueError('Write shift mode must be of ``ShiftMode`` type.')
+        if value not in c.ShiftMode:
+            raise ValueError('Write shift mode must be of ``common.ShiftMode`` type.')
         self._display_shift_mode = int(value)
-        self.command(LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
-        usleep(50)
+        self.command(c.LCD_ENTRYMODESET | self._text_align_mode | self._display_shift_mode)
+        c.usleep(50)
 
     write_shift_mode = property(_get_write_shift_mode, _set_write_shift_mode,
             doc='The shift mode when writing (``ShiftMode.cursor`` or ``ShiftMode.display``).')
 
     def _get_display_enabled(self):
-        return self._display_mode == LCD_DISPLAYON
+        return self._display_mode == c.LCD_DISPLAYON
 
     def _set_display_enabled(self, value):
-        self._display_mode = LCD_DISPLAYON if value else LCD_DISPLAYOFF
-        self.command(LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
-        usleep(50)
+        self._display_mode = c.LCD_DISPLAYON if value else c.LCD_DISPLAYOFF
+        self.command(c.LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
+        c.usleep(50)
 
     display_enabled = property(_get_display_enabled, _set_display_enabled,
             doc='Whether or not to display any characters.')
 
     def _get_cursor_mode(self):
         try:
-            return CursorMode[self._cursor_mode]
+            return c.CursorMode[self._cursor_mode]
         except ValueError:
             raise ValueError('Internal _cursor_mode has invalid value.')
 
     def _set_cursor_mode(self, value):
-        if value not in CursorMode:
+        if value not in c.CursorMode:
             raise ValueError('Cursor mode must be of ``CursorMode`` type.')
         self._cursor_mode = int(value)
-        self.command(LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
-        usleep(50)
+        self.command(c.LCD_DISPLAYCONTROL | self._display_mode | self._cursor_mode)
+        c.usleep(50)
 
     cursor_mode = property(_get_cursor_mode, _set_cursor_mode,
             doc='How the cursor should behave (``CursorMode.hide``, ' +
@@ -378,7 +219,7 @@ class CharLCD(object):
         if not isinstance(value, bool):
             raise ValueError('backlight_enabled must be set to ``True`` or ``False``.')
         self._backlight_enabled = value
-        GPIO.output(self.pins.backlight, value ^ (self.backlight_mode is BacklightMode.active_low))
+        GPIO.output(self.pins.backlight, value ^ (self.backlight_mode is c.BacklightMode.active_low))
 
     backlight_enabled = property(_get_backlight_enabled, _set_backlight_enabled,
             doc='Whether or not to turn on the backlight.')
@@ -438,33 +279,33 @@ class CharLCD(object):
                 else:
                     self.cursor_pos = (0, col)
             elif char == '\r':
-                if self.text_align_mode is Alignment.left:
+                if self.text_align_mode is c.Alignment.left:
                     self.cursor_pos = (row, 0)
                 else:
                     self.cursor_pos = (row, self.lcd.cols - 1)
 
     def clear(self):
         """Overwrite display with blank characters and reset cursor position."""
-        self.command(LCD_CLEARDISPLAY)
+        self.command(c.LCD_CLEARDISPLAY)
         self._cursor_pos = (0, 0)
         self._content = [[0x20] * self.lcd.cols for _ in range(self.lcd.rows)]
-        msleep(2)
+        c.msleep(2)
 
     def home(self):
         """Set cursor to initial position and reset any shifting."""
-        self.command(LCD_RETURNHOME)
+        self.command(c.LCD_RETURNHOME)
         self._cursor_pos = (0, 0)
-        msleep(2)
+        c.msleep(2)
 
     def shift_display(self, amount):
         """Shift the display. Use negative amounts to shift left and positive
         amounts to shift right."""
         if amount == 0:
             return
-        direction = LCD_MOVERIGHT if amount > 0 else LCD_MOVELEFT
+        direction = c.LCD_MOVERIGHT if amount > 0 else c.LCD_MOVELEFT
         for i in range(abs(amount)):
-            self.command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | direction)
-            usleep(50)
+            self.command(c.LCD_CURSORSHIFT | c.LCD_DISPLAYMOVE | direction)
+            c.usleep(50)
 
     def create_char(self, location, bitmap):
         """Create a new character.
@@ -506,9 +347,9 @@ class CharLCD(object):
         pos = self.cursor_pos
 
         # Write character to CGRAM
-        self.command(LCD_SETCGRAMADDR | location << 3)
+        self.command(c.LCD_SETCGRAMADDR | location << 3)
         for row in bitmap:
-            self._send(row, RS_DATA)
+            self._send(row, c.RS_DATA)
 
         # Restore cursor pos
         self.cursor_pos = pos
@@ -517,7 +358,7 @@ class CharLCD(object):
 
     def command(self, value):
         """Send a raw command to the LCD."""
-        self._send(value, RS_INSTRUCTION)
+        self._send(value, c.RS_INSTRUCTION)
 
     def write(self, value):
         """Write a raw byte to the LCD."""
@@ -527,14 +368,14 @@ class CharLCD(object):
 
         # Write byte if changed
         if self._content[row][col] != value:
-            self._send(value, RS_DATA)
+            self._send(value, c.RS_DATA)
             self._content[row][col] = value  # Update content cache
             unchanged = False
         else:
             unchanged = True
 
         # Update cursor position.
-        if self.text_align_mode is Alignment.left:
+        if self.text_align_mode is c.Alignment.left:
             if self.auto_linebreaks is False or col < self.lcd.cols - 1:
                 # No newline, update internal pointer
                 newpos = (row, col + 1)
@@ -566,46 +407,3 @@ class CharLCD(object):
                 else:
                     self.cursor_pos = (0, self.lcd.cols - 1)
                 self.recent_auto_linebreak = True
-
-    # Low level commands
-
-    def _send(self, value, mode):
-        """Send the specified value to the display with automatic 4bit / 8bit
-        selection. The rs_mode is either ``RS_DATA`` or ``RS_INSTRUCTION``."""
-
-        # Choose instruction or data mode
-        GPIO.output(self.pins.rs, mode)
-
-        # If the RW pin is used, set it to low in order to write.
-        if self.pins.rw is not None:
-            GPIO.output(self.pins.rw, 0)
-
-        # Write data out in chunks of 4 or 8 bit
-        if self.data_bus_mode == LCD_8BITMODE:
-            self._write8bits(value)
-        else:
-            self._write4bits(value >> 4)
-            self._write4bits(value)
-
-    def _write4bits(self, value):
-        """Write 4 bits of data into the data bus."""
-        for i in range(4):
-            bit = (value >> i) & 0x01
-            GPIO.output(self.pins[i + 7], bit)
-        self._pulse_enable()
-
-    def _write8bits(self, value):
-        """Write 8 bits of data into the data bus."""
-        for i in range(8):
-            bit = (value >> i) & 0x01
-            GPIO.output(self.pins[i + 3], bit)
-        self._pulse_enable()
-
-    def _pulse_enable(self):
-        """Pulse the `enable` flag to process data."""
-        GPIO.output(self.pins.e, 0)
-        usleep(1)
-        GPIO.output(self.pins.e, 1)
-        usleep(1)
-        GPIO.output(self.pins.e, 0)
-        usleep(100)  # commands need > 37us to settle

--- a/RPLCD/lcd.py
+++ b/RPLCD/lcd.py
@@ -24,8 +24,6 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 from collections import namedtuple
 
-import RPi.GPIO as GPIO
-
 from . import common as c
 from .compat import range
 
@@ -205,24 +203,6 @@ class BaseCharLCD(object):
     cursor_mode = property(_get_cursor_mode, _set_cursor_mode,
             doc='How the cursor should behave (``CursorMode.hide``, ' +
                                    '``CursorMode.line`` or ``CursorMode.blink``).')
-
-    def _get_backlight_enabled(self):
-        # We could probably read the current GPIO output state via sysfs, but
-        # for now let's just store the state in the class
-        if self.pins.backlight is None:
-            raise ValueError('You did not configure a GPIO pin for backlight control!')
-        return bool(self._backlight_enabled)
-
-    def _set_backlight_enabled(self, value):
-        if self.pins.backlight is None:
-            raise ValueError('You did not configure a GPIO pin for backlight control!')
-        if not isinstance(value, bool):
-            raise ValueError('backlight_enabled must be set to ``True`` or ``False``.')
-        self._backlight_enabled = value
-        GPIO.output(self.pins.backlight, value ^ (self.backlight_mode is c.BacklightMode.active_low))
-
-    backlight_enabled = property(_get_backlight_enabled, _set_backlight_enabled,
-            doc='Whether or not to turn on the backlight.')
 
     # High level commands
 

--- a/show_charmap.py
+++ b/show_charmap.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2013-2015 Danilo Bargen
+Copyright (C) 2013-2016 Danilo Bargen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -25,7 +25,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import sys
 
-from RPLCD import CharLCD
+from RPLCD.i2c import CharLCD
 
 
 try:
@@ -50,7 +50,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     rows, cols = int(sys.argv[1]), int(sys.argv[2])
-    lcd = CharLCD(cols=cols, rows=rows)
+    lcd = CharLCD(0x3f, cols=cols, rows=rows)
 
     print('This tool shows the character map of your LCD on the display.')
     print('Press ctrl+c at any time to abort.\n')

--- a/test_16x2.py
+++ b/test_16x2.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-import sys
-
 from RPLCD.i2c import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
 from RPLCD import cursor, cleared
@@ -135,6 +133,9 @@ lcd.write_string('999456\n\r\n123')
 input('The display should show "123456" on the first line')
 
 lcd.clear()
-lcd.backlight_enabled = False
+try:
+    lcd.backlight_enabled = False
+except ValueError:
+    pass
 lcd.close()
 print('Test done. If you have a backlight, it should now be off.')

--- a/test_16x2.py
+++ b/test_16x2.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-from RPLCD.i2c import CharLCD
+from RPLCD.gpio import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
 from RPLCD import cursor, cleared
 from RPLCD import BacklightMode
@@ -18,7 +18,7 @@ except NameError:
     unichr = chr
 
 
-lcd = CharLCD(0x3f, cols=16, rows=2)
+lcd = CharLCD(cols=16, rows=2)
 # if you have a backlight circuit, initialize like this (substituting the
 # appropriate GPIO and BacklightMode for your backlight circuit):
 #lcd = CharLCD(cols=16, rows=2, pin_backlight=7, backlight_mode=BacklightMode.active_high)

--- a/test_16x2.py
+++ b/test_16x2.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import sys
 
-from RPLCD import CharLCD
+from RPLCD.i2c import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
 from RPLCD import cursor, cleared
 from RPLCD import BacklightMode
@@ -20,7 +20,7 @@ except NameError:
     unichr = chr
 
 
-lcd = CharLCD(cols=16, rows=2)
+lcd = CharLCD(0x3f, cols=16, rows=2)
 # if you have a backlight circuit, initialize like this (substituting the
 # appropriate GPIO and BacklightMode for your backlight circuit):
 #lcd = CharLCD(cols=16, rows=2, pin_backlight=7, backlight_mode=BacklightMode.active_high)

--- a/test_16x2.py
+++ b/test_16x2.py
@@ -135,6 +135,6 @@ lcd.write_string('999456\n\r\n123')
 input('The display should show "123456" on the first line')
 
 lcd.clear()
-lcd.backlight = False
+lcd.backlight_enabled = False
 lcd.close()
 print('Test done. If you have a backlight, it should now be off.')

--- a/test_20x4.py
+++ b/test_20x4.py
@@ -23,7 +23,6 @@ except NameError:
 lcd = CharLCD(0x3f)
 # see note in test_16x2.py about configuring your backlight, if you have one
 
-lcd.backlight = True
 input('Display should be blank. ')
 
 lcd.cursor_mode = CursorMode.blink
@@ -131,7 +130,7 @@ lcd.write_string('999456..............\n\r\n\n\n123')
 input('The display should show "123456...................." on the first line')
 
 lcd.clear()
-lcd.backlight = False
+lcd.backlight_enabled = False
 lcd.close()
 print('Test done. If you have a backlight, it should now be off.')
 

--- a/test_20x4.py
+++ b/test_20x4.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import sys
 
-from RPLCD import CharLCD
+from RPLCD.i2c import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
 from RPLCD import cursor, cleared
 from RPLCD import BacklightMode
@@ -20,7 +20,7 @@ except NameError:
     unichr = chr
 
 
-lcd = CharLCD()
+lcd = CharLCD(0x3f)
 # see note in test_16x2.py about configuring your backlight, if you have one
 
 lcd.backlight = True

--- a/test_20x4.py
+++ b/test_20x4.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-import sys
-
 from RPLCD.i2c import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
 from RPLCD import cursor, cleared
@@ -130,7 +128,10 @@ lcd.write_string('999456..............\n\r\n\n\n123')
 input('The display should show "123456...................." on the first line')
 
 lcd.clear()
-lcd.backlight_enabled = False
+try:
+    lcd.backlight_enabled = False
+except ValueError:
+    pass
 lcd.close()
 print('Test done. If you have a backlight, it should now be off.')
 


### PR DESCRIPTION
Yay, finally!

Fixes #20.

The commonly used I2C boards have backlight control onboard, so no GPIO pins are necessary (refs #8, #21).

To do:

- Document (probably in a separate PR)
- Add a backwards compatible interface with deprecation warnings