### PR TITLE
Deprecate context managers?

### DIFF
--- a/RPLCD/contextmanagers.py
+++ b/RPLCD/contextmanagers.py
@@ -1,40 +1,25 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import warnings
 from contextlib import contextmanager
 
 
 @contextmanager
 def cursor(lcd, row, col):
-    """Context manager to control cursor position.
-
-    Args:
-        lcd:
-            The CharLCD instance.
-        row:
-            The target row (0 index based).
-        col:
-            The target column (0 index based).
-
-    Example:
-
-    >>> with cursor(lcd, 2, 0):
-        lcd.write_string('This is the hird row')
-
     """
+    Context manager to control cursor position. DEPRECATED.
+    """
+    warnings.warn('The `cursor` context manager is deprecated', DeprecationWarning)
     lcd.cursor_pos = (row, col)
     yield
 
 
 @contextmanager
 def cleared(lcd):
-    """Context manager to clear display before writing.
-
-    Example:
-
-    >>> with cleared(lcd):
-        lcd.write_string('Clear display, wooo!')
-
     """
+    Context manager to clear display before writing. DEPRECATED.
+    """
+    warnings.warn('The `cursor` context manager is deprecated', DeprecationWarning)
     lcd.clear()
     yield

--- a/test_16x2.py
+++ b/test_16x2.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 from RPLCD.gpio import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
-from RPLCD import cursor, cleared
+from RPLCD import cursor
 from RPLCD import BacklightMode
 
 try:
@@ -64,15 +64,15 @@ input('The string "cursor" should now be on the second row, column 0. ')
 lcd.home()
 input('Cursor should now be at initial position. Everything should be shifted to the right by 5 characters. ')
 
-with cursor(lcd, 1, 15):
-    lcd.write_string('X')
+lcd.cursor_pos = (1, 15)
+lcd.write_string('X')
 input('The last character on the LCD should now be an "X"')
 
 lcd.display_enabled = False
 input('Display should now be blank. ')
 
-with cleared(lcd):
-    lcd.write_string('Eggs, Ham\n\rand Spam')
+lcd.clear()
+lcd.write_string('Eggs, Ham\n\rand Spam')
 lcd.display_enabled = True
 input('Display should now show "Eggs, Ham and Spam" with a line break after "Ham". ')
 

--- a/test_20x4.py
+++ b/test_20x4.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 from RPLCD.i2c import CharLCD
 from RPLCD import Alignment, CursorMode, ShiftMode
-from RPLCD import cursor, cleared
+from RPLCD import cursor
 from RPLCD import BacklightMode
 
 try:
@@ -63,15 +63,15 @@ input('The string "cursor" should now be on the third row, column 0. ')
 lcd.home()
 input('Cursor should now be at initial position. Everything should be shifted to the right by 5 characters. ')
 
-with cursor(lcd, 3, 19):
-    lcd.write_string('X')
+lcd.cursor_pos = (3, 19)
+lcd.write_string('X')
 input('The last character on the LCD should now be an "X"')
 
 lcd.display_enabled = False
 input('Display should now be blank. ')
 
-with cleared(lcd):
-    lcd.write_string('Eggs, Ham, Bacon\n\rand Spam')
+lcd.clear()
+lcd.write_string('Eggs, Ham, Bacon\n\rand Spam')
 lcd.display_enabled = True
 input('Display should now show "Eggs, Ham, Bacon and Spam". ')
 


### PR DESCRIPTION
I think introducing the pseudo-context-managers was a mistake.

They do not really provide a context if they don't reset the state afterwards.

Instead of this

``` python
>>> with cleared(lcd):
>>>     lcd.write_string(u'LCD is cleared.')
```

...you could simply write...

``` python
>>> lcd.clear()
>>> lcd.write_string(u'LCD is cleared.')
```

That's more explicit and makes more sense. Therefore I think the managers should be deprecated.

This would also kill #12.
