### PR TITLE
Fix auto line break bug

### DIFF
--- a/RPLCD/codecs/__init__.py
+++ b/RPLCD/codecs/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-import itertools
-
+from ..common import sliding_window
 from . import hd44780_a00, hd44780_a02
 
 
@@ -10,20 +9,6 @@ from . import hd44780_a00, hd44780_a02
 # Negative to avoid conflict with regular bytes.
 CR = -1
 LF = -2
-
-
-def _window(seq, lookahead):
-    """
-    Create a sliding window with the specified number of lookahead characters.
-    """
-    it = itertools.chain(iter(seq), ' ' * lookahead)  # Padded iterator
-    window_size = lookahead + 1
-    result = tuple(itertools.islice(it, window_size))
-    if len(result) == window_size:
-        yield result
-    for elem in it:
-        result = result[1:] + (elem,)
-        yield result
 
 
 class FoundMultiCharMapping(Exception):
@@ -43,7 +28,7 @@ class Codec(object):
 
     def encode(self, input_):  # type: (str) -> List[int]
         result = []
-        window_iter = _window(input_, self.codec.combined_chars_lookahead)
+        window_iter = sliding_window(input_, self.codec.combined_chars_lookahead)
         while True:
             try:
                 window = next(window_iter)

--- a/RPLCD/common.py
+++ b/RPLCD/common.py
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import itertools
 import time
 
 from . import enum
@@ -109,3 +110,17 @@ def msleep(milliseconds):
 def usleep(microseconds):
     """Sleep the specified amount of microseconds."""
     time.sleep(microseconds / 1000000.0)
+
+
+def sliding_window(seq, lookahead):
+    """
+    Create a sliding window with the specified number of lookahead characters.
+    """
+    it = itertools.chain(iter(seq), ' ' * lookahead)  # Padded iterator
+    window_size = lookahead + 1
+    result = tuple(itertools.islice(it, window_size))
+    if len(result) == window_size:
+        yield result
+    for elem in it:
+        result = result[1:] + (elem,)
+        yield result

--- a/RPLCD/lcd.py
+++ b/RPLCD/lcd.py
@@ -364,12 +364,19 @@ class BaseCharLCD(object):
         row, col = self._cursor_pos
 
         # Write byte if changed
-        if self._content[row][col] != value:
+        try:
+            if self._content[row][col] != value:
+                self._send_data(value)
+                self._content[row][col] = value  # Update content cache
+                unchanged = False
+            else:
+                unchanged = True
+        except IndexError as e:
+            # Position out of range
+            if self.auto_linebreaks is True:
+                raise e
             self._send_data(value)
-            self._content[row][col] = value  # Update content cache
             unchanged = False
-        else:
-            unchanged = True
 
         # Update cursor position.
         if self.text_align_mode is c.Alignment.left:

--- a/RPLCD/lcd.py
+++ b/RPLCD/lcd.py
@@ -256,7 +256,8 @@ class BaseCharLCD(object):
                 self.write(char)
                 ignored = None
                 continue
-            # If an auto linebreak happened recently, ignore this write.
+            # We're now left with only CR and LF characters. If an auto
+            # linebreak happened recently, ignore this write.
             if self.recent_auto_linebreak is True:
                 # No newline chars have been ignored yet. Do it this time.
                 if ignored is None:
@@ -267,6 +268,7 @@ class BaseCharLCD(object):
                 # ignored character tracking.
                 if ignored != char:  # A carriage return and a newline
                     ignored = None  # Reset ignore list
+                    self.recent_auto_linebreak = False  # This has now been handled
                     continue
             # Handle newlines and carriage returns
             row, col = self.cursor_pos

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -191,8 +191,8 @@ Automatic Line Breaks
 By default, RPLCD tries to automatically insert line breaks where appropriate
 to achieve (hopefully) intuitive line wrapping.
 
-Part of these rules is that manual linebreaks that immediately follow an
-automatically issued line break are ignored.
+Part of these rules is that manual linebreaks (either ``\r\n`` or ``\n\r``) that
+immediately follow an automatically issued line break are ignored.
 
 If you want more control over line breaks, you can disable the automatic system
 by setting the ``auto_linebreaks`` parameter of the ``CharLCD`` constructor to

--- a/tests/test_auto_linebreaks.py
+++ b/tests/test_auto_linebreaks.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import pytest
+
+from RPLCD.gpio import CharLCD
+
+
+try:
+    unichr = unichr
+except NameError:  # Python 3
+    unichr = chr
+
+
+SP = 32  # Space
+
+
+@pytest.fixture
+def get_lcd(mocker):
+    def _func(cols, rows, auto_linebreaks):
+        lcd = CharLCD(cols=cols, rows=rows, auto_linebreaks=auto_linebreaks)
+        mocker.patch.object(lcd, '_send_data')
+        mocker.patch.object(lcd, '_send_instruction')
+        return lcd
+    return _func
+
+
+def test_auto_linebreaks(get_lcd):
+    """
+    Simple auto linebreak.
+    """
+    lcd = get_lcd(16, 2, True)
+    for i in range(48, 67):
+        lcd.write_string(unichr(i))
+    assert lcd._content[0] == [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+    assert lcd._content[1] == [64, 65, 66, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP]
+
+
+def test_no_auto_linebreaks(get_lcd):
+    """
+    Auto linebreaks disabled.
+    """
+    lcd = get_lcd(16, 2, False)
+    for i in range(48, 67):
+        lcd.write_string(unichr(i))
+    assert lcd._content[0] == [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+    assert lcd._content[1] == [SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP]
+
+
+def test_auto_linebreaks_no_ignore_lf(get_lcd):
+    """
+    Do not ignore manual \n after auto linebreak.
+    """
+    lcd = get_lcd(16, 2, True)
+    lcd.write_string('a' * 16)  # Fill up line
+    lcd.write_string('\nb')
+    assert lcd._content[0] == [98, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97]
+    assert lcd._content[1] == [SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP, SP]
+
+
+def test_auto_linebreaks_no_ignore_double_lf(get_lcd):
+    """
+    Do not ignore manual \n\n after auto linebreak.
+    """
+    lcd = get_lcd(20, 4, True)
+    lcd.write_string('a' * 20)  # Fill up line
+    lcd.write_string('\n\nb')
+    assert lcd._content[0] == [97] * 20
+    assert lcd._content[1] == [SP] * 20
+    assert lcd._content[2] == [SP] * 20
+    assert lcd._content[3] == [98] + [SP] * 19
+
+
+@pytest.mark.parametrize('pattern', ['\r\n', '\n\r'])
+def test_auto_linebreaks_ignore_crlf(get_lcd, pattern):
+    """
+    Ignore manual \r\n and \n\r after auto linebreak.
+    """
+    lcd = get_lcd(20, 4, True)
+    lcd.write_string('a' * 20)  # Fill up line
+    lcd.write_string(pattern)
+    lcd.write_string('b')
+    assert lcd._content[0] == [97] * 20
+    assert lcd._content[1] == [98] + [SP] * 19
+    assert lcd._content[2] == [SP] * 20
+    assert lcd._content[3] == [SP] * 20

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -6,18 +6,6 @@ import pytest
 from RPLCD import codecs
 
 
-@pytest.mark.parametrize(['input_', 'lookahead', 'result'], [
-    ('hi', 0, [('h',), ('i',)]),
-    ('hi', 1, [('h', 'i'), ('i', ' ')]),
-    ('hi', 2, [('h', 'i', ' '), ('i', ' ', ' ')]),
-    ('', 0, []),
-    ('', 1, []),
-    ('', 7, []),
-])
-def test_window_function(input_, lookahead, result):
-    assert list(codecs._window(input_, lookahead)) == result
-
-
 @pytest.mark.parametrize(['input_', 'result_a00', 'result_a02'], [
     # Empty
     ('', [], []),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import pytest
+
+from RPLCD import common
+
+
+@pytest.mark.parametrize(['input_', 'lookahead', 'result'], [
+    ('hi', 0, [('h',), ('i',)]),
+    ('hi', 1, [('h', 'i'), ('i', ' ')]),
+    ('hi', 2, [('h', 'i', ' '), ('i', ' ', ' ')]),
+    ('', 0, []),
+    ('', 1, []),
+    ('', 7, []),
+])
+def test_window_function(input_, lookahead, result):
+    assert list(common.sliding_window(input_, lookahead)) == result


### PR DESCRIPTION
When writing the combination '\n\r\n' or '\r\n\n' at the end of a line, the internal recent auto linebreak flag wasn't cleared properly, causing another newline character to be ignored.

Fixes #33.