### PR TITLE
Added support for pigpio backend.

### DIFF
--- a/RPLCD/pigpio.py
+++ b/RPLCD/pigpio.py
@@ -295,14 +295,14 @@ class CharLCD(BaseCharLCD):
 
         # Assemble the parameters sent to the pigpio script
         params = [mode]
-        params.extend([(value >> i) & 0x01 for i in range(8)]
+        params.extend([(value >> i) & 0x01 for i in range(8)])
         # Switch off pigpio's exceptions, so that we get the return codes
         pigpio.exceptions = False
         while True:
             ret = self.pi.run_script(self._writescript, params)
             if ret >= 0:
                 break
-            elif ret != pigpio.PI_SCRIPT_NOT_READY
+            elif ret != pigpio.PI_SCRIPT_NOT_READY:
                 raise pigpio.error(pigpio.error_text(ret))
             # If pigpio script is not ready, sleep and try again
             c.usleep(1)

--- a/RPLCD/pigpio.py
+++ b/RPLCD/pigpio.py
@@ -56,7 +56,7 @@ class CharLCD(BaseCharLCD):
         """
         Character LCD controller.
 
-        The default pin numbers are based on the BCM numbering scheme!
+        The pin numbers are based on the BCM numbering scheme!
 
         You can save 1 pin by not using RW. Set ``pin_rw`` to ``None`` if you
         want this.

--- a/RPLCD/pigpio.py
+++ b/RPLCD/pigpio.py
@@ -192,7 +192,8 @@ class CharLCD(BaseCharLCD):
         # pigpio script to write data to the LCD
         piscript = ['write {pin.rs} p0']        # Choose instruction or data mode
         if self.pins.rw is not None:
-            piscript.append('write {pin.rw} 0') # If the RW pin is used, set it to low
+            # If the RW pin is used, set it to low
+            piscript.append('write {pin.rw} 0')
         if self.data_bus_mode == c.LCD_8BITMODE:
             # Script to write 8 bits of data into the data bus.
             piscript.extend(                # Write data in 1 chunk of 8 bits
@@ -247,15 +248,20 @@ class CharLCD(BaseCharLCD):
             raise ValueError('You did not configure a GPIO pin for backlight control!')
         if self.backlight_pwm:
             if not ((0 <= value <= 1) or isinstance(value, bool)):
-                raise ValueError('backlight_enabled must be set to a value between 0 and 1 or to ``True`` or ``False``, if PWM is enabled; got {}'.format(value))
+                raise ValueError(
+                        'backlight_enabled must be set to a value '
+                        'between 0 and 1 or to ``True`` or ``False``, '
+                        'if PWM is enabled; got {}'.format(value))
         else:
             if not isinstance(value, bool):
-                raise ValueError('backlight_enabled must be set to ``True`` or ``False``, if PWM is not enabled; got: {}'.format(value))
+                raise ValueError(
+                        'backlight_enabled must be set to ``True`` or ``False``, '
+                        'if PWM is not enabled; got: {}'.format(value))
         self._backlight_enabled = value
         if self.backlight_pwm:
             # Convert perceived brightness (as requested by `value`) to duty
             # cycle (see comment above definition of PWM):
-            dc = 2**(value/PWM)-1
+            dc = 2**(value / PWM) - 1
             if self.backlight_mode == 'active_low':
                 dc = 255 - dc
             self.pi.set_PWM_dutycycle(self.pins.backlight, round(dc))

--- a/RPLCD/pigpio.py
+++ b/RPLCD/pigpio.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (C) 2013-2017 Danilo Bargen
+Copyright (C) 2018 Stephan Helma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+from __future__ import division, absolute_import, unicode_literals
+
+from collections import namedtuple
+
+import pigpio
+
+from . import common as c
+from .lcd import BaseCharLCD
+from .compat import range
+
+
+# https://diarmuid.ie/blog/pwm-exponential-led-fading-on-arduino-or-other-platforms/
+# p 101 .. maximum value of the PWM cycle
+# m 100 .. number of steps the LED will fade over
+# r = m*LOG(2)/LOG(p) = 12.5
+# dc = 2**(x/r)-1 with x[0..1] and y[0..255]
+PWM = 0.125
+
+PinConfig = namedtuple('PinConfig', 'rs rw e e2 d0 d1 d2 d3 d4 d5 d6 d7 backlight contrast')
+
+
+class CharLCD(BaseCharLCD):
+    def __init__(self, pi,
+                       pin_rs=None, pin_rw=None, pin_e=None, pin_e2=None,
+                       pins_data=None,
+                       pin_backlight=None, backlight_mode='active_low',
+                       backlight_pwm=False, backlight_enabled=True,
+                       pin_contrast=None, contrast_mode='active_high',
+                       contrast_pwm=None, contrast=0.5,
+                       cols=20, rows=4, dotsize=8,
+                       charmap='A02',
+                       auto_linebreaks=True):
+        """
+        Character LCD controller.
+
+        The default pin numbers are based on the BCM numbering scheme!
+
+        You can save 1 pin by not using RW. Set ``pin_rw`` to ``None`` if you
+        want this.
+
+        :param pi: A pigpio.pi object to access the GPIOs.
+        :type pi: pigpio.pi object
+        :param pin_rs: Pin for register select (RS). Default: ``15``.
+        :type pin_rs: int
+        :param pin_rw: Pin for selecting read or write mode (R/W). Set this to
+            ``None`` for read only mode. Default: ``18``.
+        :type pin_rw: int
+        :param pin_e: Pin to start data read or write (E). Default: ``16``.
+        :type pin_e: int
+        :param pins_data: List of data bus pins in 8 bit mode (DB0-DB7) or in 4
+            bit mode (DB4-DB7) in ascending order. Default: ``[21, 22, 23, 24]``.
+        :type pins_data: list of int
+        :param pin_backlight: Pin for controlling backlight on/off. Set this to
+            ``None`` for no backlight control. Default: ``None``.
+        :type pin_backlight: int
+        :param backlight_mode: Set this to either ``active_high`` or ``active_low``
+            to configure the operating control for the backlight. Has no effect if
+            pin_backlight is ``None``.
+        :type backlight_mode: str
+        :param backlight_pwm: Set this to ``True``, if you want to enable PWM
+            for the backlight with the default PWM frequency. Set this to the
+            frequency (in Hz) of the PWM for the backlight or to ``False`` to
+            disable PWM for the backlight. Default: ``False``. Has no effect
+            if pin_backlight is ``None``.
+        :type backlight_pwm: bool or int
+        :param backlight_enabled: Whether the backlight is enabled initially.
+            If backlight_pwm is ``True``, this can be a value between 0 and 1,
+            specifying the initial backlight level. Default: ``True``. Has no
+            effect if pin_backlight is ``None``.
+        :type backlight_enabled: bool or float
+        :param pin_contrast: Pin for controlling LCD contrast. Set this to
+            ``None`` for no contrast control. Default: ``None``.
+        :type pin_contrast: int
+        :param contrast_mode: Set this to either ``active_high`` or
+            ``active_low`` to configure the operating control for the LCD
+            contrast. Has no effect if pin_contrast is ``None``.
+        :type contrast_mode: str
+        :param contrast_pwm: Set this to the frequency (in Hz) of the PWM for
+            the LCD contrast if you want to change the default value. Has no
+            effect if pin_contrast is ``None``.
+        :type contrast_pwm: int
+        :param contrast: A value between 0 and 1, specifying the initial LCD
+            contrast. Default: 0.5. Has no effect if pin_contrast is ``None``
+        :type contrast: float
+        :param rows: Number of display rows (usually 1, 2 or 4). Default: ``4``.
+        :type rows: int
+        :param cols: Number of columns per row (usually 16 or 20). Default ``20``.
+        :type cols: int
+        :param dotsize: Some 1 line displays allow a font height of 10px.
+            Allowed: ``8`` or ``10``. Default: ``8``.
+        :type dotsize: int
+        :param charmap: The character map used. Depends on your LCD. This must
+            be either ``A00`` or ``A02``. Default: ``A02``.
+        :type charmap: str
+        :param auto_linebreaks: Whether or not to automatically insert line
+            breaks. Default: ``True``.
+        :type auto_linebreaks: bool
+
+        """
+
+        # Save the pigpio.pi object
+        self.pi = pi
+
+        # Set attributes
+        if pin_rs is None:
+            raise ValueError('pin_rs is not defined.')
+        if pin_e is None:
+            raise ValueError('pin_e is not defined.')
+
+        if len(pins_data) == 4:  # 4 bit mode
+            self.data_bus_mode = c.LCD_4BITMODE
+            block1 = [None] * 4
+        elif len(pins_data) == 8:  # 8 bit mode
+            self.data_bus_mode = c.LCD_8BITMODE
+            block1 = pins_data[:4]
+        else:
+            raise ValueError('There should be exactly 4 or 8 data pins.')
+        block2 = pins_data[-4:]
+        self.pins = PinConfig(rs=pin_rs, rw=pin_rw, e=pin_e, e2=pin_e2,
+                              d0=block1[0], d1=block1[1], d2=block1[2], d3=block1[3],
+                              d4=block2[0], d5=block2[1], d6=block2[2], d7=block2[3],
+                              backlight=pin_backlight, contrast=pin_contrast)
+        self.backlight_mode = backlight_mode
+        self.backlight_pwm = backlight_pwm
+        self.contrast_mode = contrast_mode
+        self.contrast_pwm = contrast_pwm
+
+        # Call superclass
+        super(CharLCD, self).__init__(cols, rows, dotsize,
+                                      charmap=charmap,
+                                      auto_linebreaks=auto_linebreaks)
+
+        # Set backlight status
+        if pin_backlight is not None:
+            self.backlight_enabled = backlight_enabled
+
+        # Set contrast
+        self.contrast = contrast
+
+    def _init_connection(self):
+        # Setup GPIO
+        for pin in list(filter(None, self.pins)):
+            self.pi.set_mode(pin, pigpio.OUTPUT)
+
+        # Setup PWM
+        if self.pins.backlight and self.backlight_pwm:
+            if self.backlight_pwm is not True:
+                self.pi.set_PWM_frequency(self.pins.backlight, self.backlight_pwm)
+        if self.pins.contrast:
+            if self.backlight_pwm not in (None, False, True):
+                self.pi.set_PWM_frequency(self.pins.contrast, self.contrast_pwm)
+
+        # Initialization
+        c.msleep(50)
+        self.pi.write(self.pins.rs, 0)
+        self.pi.write(self.pins.e, 0)
+        if self.pins.e2 is not None:
+            self.pi.write(self.pins.e2, 0)
+        if self.pins.rw is not None:
+            self.pi.write(self.pins.rw, 0)
+
+        # pigpio script to pulse the enable flag to process data
+        enablepulse = [
+                'write {pin.e} 0',
+                'mics 1',
+                'trig {pin.e} 1 1',
+                'mics 100']                 # Commands need > 37us to settle
+
+        # pigpio script to write data to the LCD
+        piscript = ['write {pin.rs} p0']        # Choose instruction or data mode
+        if self.pins.rw is not None:
+            piscript.append('write {pin.rw} 0') # If the RW pin is used, set it to low
+        if self.data_bus_mode == c.LCD_8BITMODE:
+            # Script to write 8 bits of data into the data bus.
+            piscript.extend(                # Write data in 1 chunk of 8 bits
+                    ['write {pin.d0} p1',       # Write 8 bits of data into the data bus
+                     'write {pin.d1} p2',
+                     'write {pin.d2} p3',
+                     'write {pin.d3} p4',
+                     'write {pin.d4} p5',
+                     'write {pin.d5} p6',
+                     'write {pin.d6} p7',
+                     'write {pin.d7} p8'])
+            piscript.extend(enablepulse)    # Process data
+        else:
+            piscript.extend(                # Write data in 2 chunks of 4 bits
+                    ['write {pin.d4} p5',       # Write 4 bits of data into the data bus
+                     'write {pin.d5} p6',
+                     'write {pin.d6} p7',
+                     'write {pin.d7} p8'])
+            piscript.extend(enablepulse)    # Process data
+            piscript.extend(
+                    ['write {pin.d4} p1',       # Write 4 bits of data into the data bus
+                     'write {pin.d5} p2',
+                     'write {pin.d6} p3',
+                     'write {pin.d7} p4'])
+            piscript.extend(enablepulse)    # Process data
+
+        # Make one string and insert the pin values
+        piscript = ' '.join(piscript).format(pin=self.pins)
+        # Send the string to pigpiod (it expects a byte string)
+        self._writescript = self.pi.store_script(bytes(piscript, 'utf-8'))
+
+    def _close_connection(self):
+
+        while self.pi.script_status(self._writescript) == pigpio.PI_SCRIPT_RUNNING:
+            c.msleep(10)
+        self.pi.delete_script(self._writescript)
+
+        self.pi.stop()
+
+    # Properties
+
+    def _get_backlight_enabled(self):
+        if self.pins.backlight is None:
+            raise ValueError('You did not configure a GPIO pin for backlight control!')
+        if self.backlight_pwm:
+            return self._backlight_enabled
+        else:
+            return bool(self._backlight_enabled)
+
+    def _set_backlight_enabled(self, value):
+        if self.pins.backlight is None:
+            raise ValueError('You did not configure a GPIO pin for backlight control!')
+        if self.backlight_pwm:
+            if not ((0 <= value <= 1) or isinstance(value, bool)):
+                raise ValueError('backlight_enabled must be set to a value between 0 and 1 or to ``True`` or ``False``, if PWM is enabled; got {}'.format(value))
+        else:
+            if not isinstance(value, bool):
+                raise ValueError('backlight_enabled must be set to ``True`` or ``False``, if PWM is not enabled; got: {}'.format(value))
+        self._backlight_enabled = value
+        if self.backlight_pwm:
+            # Convert perceived brightness (as requested by `value`) to duty
+            # cycle (see comment above definition of PWM):
+            dc = 2**(value/PWM)-1
+            if self.backlight_mode == 'active_low':
+                dc = 255 - dc
+            self.pi.set_PWM_dutycycle(self.pins.backlight, round(dc))
+        else:
+            self.pi.write(self.pins.backlight,
+                          value ^ (self.backlight_mode == 'active_low'))
+
+    backlight_enabled = property(_get_backlight_enabled, _set_backlight_enabled,
+            doc='Turn on/off or set the brightness of the backlight.')
+
+    def _get_contrast(self):
+        # We could probably read the current GPIO output state via sysfs, but
+        # for now let's just store the state in the class
+        if self.pins.contrast is None:
+            raise ValueError('You did not configure a GPIO pin for contrast control!')
+        return self._contrast
+
+    def _set_contrast(self, value):
+        if self.pins.contrast is None:
+            raise ValueError('You did not configure a GPIO pin for contrast control!')
+        if not (0 <= value <= 1):
+            raise ValueError('contrast must be between 0 and 1; got {}'.format(value))
+        self._contrast = value
+        dc = 255 * value
+        if self.contrast_mode == 'active_low':
+            dc = 255 - dc
+        self.pi.set_PWM_dutycycle(self.pins.contrast, round(dc))
+
+    contrast = property(_get_contrast, _set_contrast,
+            doc='Set the LCD contrast.')
+
+    # Low level commands
+
+    def _send(self, value, mode):
+        """Send the specified value to the display with automatic 4bit / 8bit
+        selection. The rs_mode is either ``RS_DATA`` or ``RS_INSTRUCTION``."""
+
+        # Assemble the parameters sent to the pigpio script
+        params = [mode]
+        params.extend([(value >> i) & 0x01 for i in range(8)]
+        # Switch off pigpio's exceptions, so that we get the return codes
+        pigpio.exceptions = False
+        while True:
+            ret = self.pi.run_script(self._writescript, params)
+            if ret >= 0:
+                break
+            elif ret != pigpio.PI_SCRIPT_NOT_READY
+                raise pigpio.error(pigpio.error_text(ret))
+            # If pigpio script is not ready, sleep and try again
+            c.usleep(1)
+        # Switch on pigpio's exceptions
+        pigpio.exceptions = True
+
+    def _send_data(self, value):
+        """Send data to the display. """
+        self._send(value, c.RS_DATA)
+
+    def _send_instruction(self, value):
+        """Send instruction to the display. """
+        self._send(value, c.RS_INSTRUCTION)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@ API
 ###
 
 CharLCD (I²C)
-==============
+=============
 
 The main class for controlling I²C connected LCDs.
 
@@ -14,3 +14,12 @@ CharLCD (GPIO)
 The main class for controlling GPIO (parallel) connected LCDs.
 
 .. autoclass:: RPLCD.gpio.CharLCD
+
+CharLCD (pigpio)
+================
+
+The main class for controlling LCDs through pigpio_.
+
+.. autoclass:: RPLCD.pigpio.CharLCD
+
+.. _pigpio: http://abyz.me.uk/rpi/pigpio/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,6 +267,7 @@ texinfo_documents = [
 
 sys.modules['RPi'] = mock.Mock()
 sys.modules['RPi.GPIO'] = mock.Mock()
+sys.modules['pigpio'] = mock.Mock()
 
 autodoc_default_flags = ['members', 'inherited-members', 'undoc-members']
 autoclass_content = 'init'

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -67,7 +67,7 @@ Via pigpio
 
 If you decide to use the ``pigpio`` library to control the LCD, follow the
 instructions set out above. Please keep in mind that the ``pigpio`` can only
-use the BOARD numbering scheme.
+use the BCM numbering scheme.
 
 The advantage of using the ``pigpio`` library is that you could control the
 backlight and contrast via PWM. You could also run the program on one computer

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -62,6 +62,20 @@ the `Adafruit tutorial
 <https://learn.adafruit.com/character-lcds/wiring-a-character-lcd>`_ to learn
 how to wire up these circuits.
 
+Via pigpio
+~~~~~~~~~~
+
+If you decide to use the ``pigpio`` library to control the LCD, follow the
+instructions set out above. Please keep in mind that the ``pigpio`` can only
+use the BOARD numbering scheme.
+
+The advantage of using the ``pigpio`` library is that you could control the
+backlight and contrast via PWM. You could also run the program on one computer
+(there is no need for this computer to be a Raspberry Pi) and control a LCD on
+any Raspberry Pi because ``pigpio`` follows a server-client approach. The
+disadvantage is, that it might be a bit slower when updating compared to using
+the GPIO library.
+
 
 Initializing the LCD
 ====================
@@ -127,6 +141,47 @@ change the corresponding parameters. Here's a full example:
 
     lcd = CharLCD(pin_rs=15, pin_rw=18, pin_e=16, pins_data=[21, 22, 23, 24],
                   numbering_mode=GPIO.BOARD,
+                  cols=20, rows=4, dotsize=8,
+                  charmap='A02',
+                  auto_linebreaks=True)
+
+Setup: pigpio
+~~~~~~~~~~~~~
+
+First, import the the pigpio and RPLCD libraries from your Python script.
+
+.. sourcecode:: python
+
+    import pigpio
+    from RPLCD.pigpio import CharLCD
+
+Then create a connection to the pigpio daemon
+
+.. sourcecode:: python
+
+    pi = pigpio.pi()
+
+and create a new instance of the :class:`~RPLCD.pigpio.CharLCD` class. If you
+have a 20x4 LCD, you must at least specify the previously initiated pigpio
+connection and the pins you used:
+
+.. sourcecode:: python
+
+    lcd = CharLCD(pi,
+                  pin_rs=15, pin_rw=18, pin_e=16, pins_data=[21, 22, 23, 24])
+
+If you want to customize the way the LCD is instantiated (e.g. by changing the
+pin configuration or the number of columns and rows on your display), you can
+change the corresponding parameters. Here's a full example:
+
+.. sourcecode:: python
+
+    import pigpio
+    from RPLCD.pigpio import CharLCD
+
+    pi = pigpio.pi()
+    lcd = CharLCD(pi,
+                  pin_rs=15, pin_rw=18, pin_e=16, pins_data=[21, 22, 23, 24],
                   cols=20, rows=4, dotsize=8,
                   charmap='A02',
                   auto_linebreaks=True)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,14 +7,16 @@ About
 
 RPLCD is a Python 2/3 Raspberry PI Character LCD library for the Hitachi HD44780
 controller. It supports both GPIO (parallel) mode as well as boards with an I²C
-port expander (e.g. the PCF8574 or the MCP23008).
+port expander (e.g. the PCF8574 or the MCP23008). Furthermore it can use the
+pigpio_ library to control the (remote) LCD.
 
 This library is inspired by Adafruit Industries' CharLCD_ library as well as by
 Arduino's LiquidCrystal_ library.
 
 For GPIO mode, no external dependencies (except the ``RPi.GPIO`` library, which
 comes preinstalled on Raspbian) are needed to use this library. If you want to
-control LCDs via I²C, then you also need the ``python-smbus`` library.
+control LCDs via I²C, then you also need the ``python-smbus`` library. If you
+want to control the LCD with ``pigpio``, you have to install the pigpio_ library.
 
 
 Features
@@ -24,9 +26,11 @@ Features
 
 - Simple to use API
 - Support for both 4 bit and 8 bit modes
-- Support for both parallel (GPIO) and I²C connection
+- Support for parallel (GPIO), I²C and ``pigpio`` connections
 - Support for custom characters
-- Support for backlight control circuits
+- Support for backlight control circuits (including PWM dimming when using the
+  ``pigpio`` backend)
+- Support for contrast control (when using the ``pigpio`` backend)
 - Built-in support for ``A00`` and ``A02`` character tables
 - Python 2/3 compatible
 - Caching: Only write characters if they changed
@@ -69,3 +73,4 @@ Indices and tables
 
 .. _charlcd: https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code/tree/master/Adafruit_CharLCD
 .. _liquidcrystal: http://arduino.cc/en/Reference/LiquidCrystal
+.. _pigpio: http://abyz.me.uk/rpi/pigpio/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,11 @@ If you want to use I²C, you also need smbus::
 
     $ sudo apt-get install python-smbus
 
+If you want to use pigpio, the easiest way is to install the library via your
+packet manager (select the Python version you need)::
+
+    $ sudo apt-get install pigpio python-pigpio python3-pigpio
+
 
 Manual Installation
 ===================

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -170,6 +170,46 @@ change that behavior by setting the  ``backlight_mode`` to either
 :attr:`~RPLCD.gpio.CharLCD.backlight_enabled` property to turn the backlight on
 and off.
 
+pigpio
+~~~~~~
+
+When using the ``pigpio`` library, it is also possible to control the backlight
+with PWM.
+
+The API is compatible to the backlight control of I²C and GPIO explained above,
+but the :attr:`~RPLCD.pigpio.CharLCD.backlight_enabled` property (and parameter)
+now also accepts a value between ``0`` and ``1`` as a backlight level (``0`` or
+``False`` turns the backlight off, ``1`` or ``True`` turns it on). The perceived
+brightness of the backlight should roughly correspond to the given value.
+
+The PWM dimming of the backlight has to be enabled explicitly by setting the
+``backlight_pwm`` parameter to ``True`` during initialization of
+:class:`~RPLCD.pigpio.CharLCD`. If this parameter is ``False`` (the default
+value), the interface only switches the backlight on and off. If this parameter
+is a number, dimming of the backlight is enabled and the value is interpreted
+as the PWM frequency in Hertz.
+
+
+Contrast Control
+================
+
+This is currently only possible with the pigpio backend.
+
+pigpio
+~~~~~~
+
+The API is similar to that controlling the backlight. The ``pin_contrast``
+specifies the pin connected to the LCDs contrast input. The ``contrast_mode``
+can be ``active_high`` or ``active_low`` and the ``contrast_pwm`` sets the PWM
+frequency.
+
+The :attr:`~RPLCD.pigpio.CharLCD.contrast` property sets the contrast level. It
+should be a value between ``0`` and ``1``. It is also recognized as a parameter
+to :class:`~RPLCD.pigpio.CharLCD` to set the initial contrast level.
+
+If you don't set the ``pin_contrast`` parameter, the contrast control stays
+disabled.
+
 
 Automatic Line Breaks
 =====================

--- a/lcdtest.py
+++ b/lcdtest.py
@@ -261,7 +261,7 @@ if __name__ == '__main__':
         pins_data = [int(pin) for pin in pins_data]
         lcd = pigpio.CharLCD(pi,
                              pin_rs=rs, pin_rw=rw, pin_e=e, pins_data=pins_data, pin_backlight=bl,
-                             numbering_mode=numbering_mode, cols=cols, rows=rows, charmap=charmap)
+                             cols=cols, rows=rows, charmap=charmap)
     else:
         print_usage('Connection type %s is not supported. Must be either i2c, gpio or pigpio' %
                     lcdmode)

--- a/lcdtest.py
+++ b/lcdtest.py
@@ -263,7 +263,8 @@ if __name__ == '__main__':
                              pin_rs=rs, pin_rw=rw, pin_e=e, pins_data=pins_data, pin_backlight=bl,
                              numbering_mode=numbering_mode, cols=cols, rows=rows, charmap=charmap)
     else:
-        print_usage('Connection type %s is not supported. Must be either i2c, gpio or pigpio' % lcdmode)
+        print_usage('Connection type %s is not supported. Must be either i2c, gpio or pigpio' %
+                    lcdmode)
 
     # Run selected test
     if test == 'show_charmap':

--- a/lcdtests/testsuite_16x2.py
+++ b/lcdtests/testsuite_16x2.py
@@ -23,8 +23,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-from RPLCD import gpio, i2c
-
 try:
     input = raw_input
 except NameError:


### PR DESCRIPTION
[pigpio](http://abyz.me.uk/rpi/pigpio/) is another GPIO library for the Raspberry Pi implementing a server-client architecture. This is a driver which connects to the pigpio daemon.

In addition it has PWM drivers for the LCD backlight and contrast. (This was the main reason to implement a driver for the pigpio daemon, because the RPi.GPIO PWM drivers resulted in a somewhat flickering backlight and if used for contrast, horizontal strips running from top to bottom of the LCD.)