### PR TITLE
Bundle test script when packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,2 @@
 include README.rst LICENSE CHANGELOG.md CONTRIBUTORS
-include lcdtest.py
-include lcdtests/*.py
 recursive-exclude * *.pyc

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Testing
 Interactive Test Script
 -----------------------
 
-To test your LCD, please run the ``lcdtest.py`` script with the ``testsuite``
+To test your LCD, please run the ``rplcd-tests`` script with the ``testsuite``
 target.
 
 Unit Tests

--- a/RPLCD_Tests/entrypoint.py
+++ b/RPLCD_Tests/entrypoint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Copyright (C) 2013-2018 Danilo Bargen
@@ -26,9 +25,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 import sys
 
 # Import supported tests
-import lcdtests.show_charmap as show_charmap
-import lcdtests.testsuite_20x4 as testsuite_20x4
-import lcdtests.testsuite_16x2 as testsuite_16x2
+from . import show_charmap, testsuite_20x4, testsuite_16x2
 
 # Globals
 options = {}
@@ -162,7 +159,7 @@ def options_pop(value, default=no_default):
     return return_value
 
 
-if __name__ == '__main__':
+def run():
     if len(sys.argv) < 3:
         print_usage()
 

--- a/RPLCD_Tests/show_charmap.py
+++ b/RPLCD_Tests/show_charmap.py
@@ -75,4 +75,4 @@ def run(lcd, rows, cols):
 
 
 if __name__ == '__main__':
-    print('This is a submodule of lcdtest.py, please run it instead.')
+    print('This is a submodule of `rplcd-tests`, please run it instead.')

--- a/RPLCD_Tests/testsuite_16x2.py
+++ b/RPLCD_Tests/testsuite_16x2.py
@@ -165,5 +165,4 @@ def run(lcd):
 
 
 if __name__ == '__main__':
-
-    print('This is a submodule of lcdtest.py, please run it instead.')
+    print('This is a submodule of `rplcd-tests`, please run it instead.')

--- a/RPLCD_Tests/testsuite_20x4.py
+++ b/RPLCD_Tests/testsuite_20x4.py
@@ -160,5 +160,4 @@ def run(lcd):
 
 
 if __name__ == '__main__':
-
-    print('This is a submodule of lcdtest.py, please run it instead.')
+    print('This is a submodule of `rplcd-tests`, please run it instead.')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -74,7 +74,7 @@ character map:
 
 As a rule of thumb, if your display can show Japanese characters, it uses
 ``A00``, otherwise ``A02``. To show the entire character map on your LCD, you
-can use the ``show_charmap`` target of the ``lcdtest.py`` script.
+can use the ``show_charmap`` target of the ``rplcd-tests`` script.
 
 Should you run into the situation that your character map does not seem to match
 either the ``A00`` or the ``A02`` tables, please `open an issue

--- a/rplcd-tests
+++ b/rplcd-tests
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from RPLCD_Tests import entrypoint
+
+if __name__ == '__main__':
+    entrypoint.run()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 readme = open('README.rst').read()
 
@@ -13,7 +13,10 @@ setup(name='RPLCD',
       url='https://github.com/dbrgn/RPLCD',
       license='MIT',
       keywords='raspberry, raspberry pi, lcd, liquid crystal, hitachi, hd44780',
-      packages=find_packages(),
+      packages=['RPLCD', 'RPLCD_Tests'],
+      entry_points={
+          'console_scripts': ['rplcd-tests=RPLCD_Tests.entrypoint:run'],
+      },
       platforms=['any'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
- Move LCD tests into separate package
- Add test script entry point to setup.py

With this change, people that install RPLCD with pip should get a new script in their bin path called `rplcd-tests`.