### PR TITLE
Fix missing declaration "global options" in RPLCD_Tests/entrypoint.py…

### DIFF
--- a/RPLCD_Tests/entrypoint.py
+++ b/RPLCD_Tests/entrypoint.py
@@ -167,6 +167,7 @@ def run():
     test = sys.argv[2]
 
     # Parse options into a dictionary
+    global options
     try:
         options = dict([arg.split('=', 1) for arg in sys.argv[3:]])
     except ValueError:


### PR DESCRIPTION
… file

for the run() function.

Used with Ubuntu Bionic 18.04 Python 3.6.6 on Rock64 sbc.