### PR TITLE
Added a legacy mode.

### DIFF
--- a/RPLCD/gpio.py
+++ b/RPLCD/gpio.py
@@ -37,7 +37,7 @@ else:
     from time import perf_counter as now
 
 # Duration to rate-limit calls to _send
-LEGACY_MODE_WAIT_TIME = 0.001
+COMPAT_MODE_WAIT_TIME = 0.001
 
 PinConfig = namedtuple('PinConfig', 'rs rw e d0 d1 d2 d3 d4 d5 d6 d7 backlight mode')
 
@@ -49,7 +49,7 @@ class CharLCD(BaseCharLCD):
                        cols=20, rows=4, dotsize=8,
                        charmap='A02',
                        auto_linebreaks=True,
-                       legacy_mode=False):
+                       compat_mode=False):
         """
         Character LCD controller.
 
@@ -94,14 +94,14 @@ class CharLCD(BaseCharLCD):
         :param auto_linebreaks: Whether or not to automatically insert line
             breaks. Default: ``True``.
         :type auto_linebreaks: bool
-        :param legacy_mode: Whether to run additional checks to support older LCDs
+        :param compat_mode: Whether to run additional checks to support older LCDs
             that may not run at the reference clock (or keep up with it).
-        :type legacy_mode: bool
+        :type compat_mode: bool
 
         """
-        # Configure legacy mode
-        self.legacy_mode = legacy_mode
-        if legacy_mode:
+        # Configure compatibility mode
+        self.compat_mode = compat_mode
+        if compat_mode:
             self.last_send_event = now()
 
         # Set attributes
@@ -190,8 +190,8 @@ class CharLCD(BaseCharLCD):
     def _send(self, value, mode):
         """Send the specified value to the display with automatic 4bit / 8bit
         selection. The rs_mode is either ``RS_DATA`` or ``RS_INSTRUCTION``."""
-        # Wait, if legacy mode is enabled
-        if self.legacy_mode:
+        # Wait, if compatibility mode is enabled
+        if self.compat_mode:
             self._wait()
 
         # Choose instruction or data mode
@@ -209,7 +209,7 @@ class CharLCD(BaseCharLCD):
             self._write4bits(value)
 
         # Record the time for the tail-end of the last send event
-        if self.legacy_mode:
+        if self.compat_mode:
             self.last_send_event = now()
 
     def _send_data(self, value):
@@ -245,6 +245,6 @@ class CharLCD(BaseCharLCD):
 
     def _wait(self):
         """Rate limit the number of send events."""
-        end = self.last_send_event + LEGACY_MODE_WAIT_TIME
+        end = self.last_send_event + COMPAT_MODE_WAIT_TIME
         while now() < end:
             pass

--- a/RPLCD/gpio.py
+++ b/RPLCD/gpio.py
@@ -30,6 +30,14 @@ from . import common as c
 from .lcd import BaseCharLCD
 from .compat import range
 
+import sys
+if sys.version_info.major < 3:
+    from time import clock as now
+else:
+    from time import perf_counter as now
+
+# Duration to rate-limit calls to _send
+LEGACY_MODE_WAIT_TIME = 0.001
 
 PinConfig = namedtuple('PinConfig', 'rs rw e d0 d1 d2 d3 d4 d5 d6 d7 backlight mode')
 
@@ -40,7 +48,8 @@ class CharLCD(BaseCharLCD):
                        backlight_enabled=True,
                        cols=20, rows=4, dotsize=8,
                        charmap='A02',
-                       auto_linebreaks=True):
+                       auto_linebreaks=True,
+                       legacy_mode=False):
         """
         Character LCD controller.
 
@@ -85,8 +94,16 @@ class CharLCD(BaseCharLCD):
         :param auto_linebreaks: Whether or not to automatically insert line
             breaks. Default: ``True``.
         :type auto_linebreaks: bool
+        :param legacy_mode: Whether to run additional checks to support older LCDs
+            that may not run at the reference clock (or keep up with it).
+        :type legacy_mode: bool
 
         """
+        # Configure legacy mode
+        self.legacy_mode = legacy_mode
+        if legacy_mode:
+            self.last_send_event = now()
+
         # Set attributes
         if numbering_mode == GPIO.BCM or numbering_mode == GPIO.BOARD:
             self.numbering_mode = numbering_mode
@@ -173,6 +190,9 @@ class CharLCD(BaseCharLCD):
     def _send(self, value, mode):
         """Send the specified value to the display with automatic 4bit / 8bit
         selection. The rs_mode is either ``RS_DATA`` or ``RS_INSTRUCTION``."""
+        # Wait, if legacy mode is enabled
+        if self.legacy_mode:
+            self._wait()
 
         # Choose instruction or data mode
         GPIO.output(self.pins.rs, mode)
@@ -187,6 +207,10 @@ class CharLCD(BaseCharLCD):
         else:
             self._write4bits(value >> 4)
             self._write4bits(value)
+
+        # Record the time for the tail-end of the last send event
+        if self.legacy_mode:
+            self.last_send_event = now()
 
     def _send_data(self, value):
         """Send data to the display. """
@@ -218,3 +242,9 @@ class CharLCD(BaseCharLCD):
         c.usleep(1)
         GPIO.output(self.pins.e, 0)
         c.usleep(100)  # commands need > 37us to settle
+
+    def _wait(self):
+        """Rate limit the number of send events."""
+        end = self.last_send_event + LEGACY_MODE_WAIT_TIME
+        while now() < end:
+            pass

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -186,6 +186,10 @@ change the corresponding parameters. Here's a full example:
                   charmap='A02',
                   auto_linebreaks=True)
 
+If you've been experiencing `issues <https://github.com/dbrgn/RPLCD/issues/70>`_
+with garbled text occasionally on initialization of the display, try setting
+the parameter ``legacy_mode=True``.
+
 Writing Data
 ~~~~~~~~~~~~
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -187,8 +187,9 @@ change the corresponding parameters. Here's a full example:
                   auto_linebreaks=True)
 
 If you've been experiencing `issues <https://github.com/dbrgn/RPLCD/issues/70>`_
-with garbled text occasionally on initialization of the display, try setting
-the parameter ``legacy_mode=True``.
+with garbled text occasionally on initialization/use of the display, try setting
+the parameter ``compat_mode=True``, which allows for better interoperability with
+slower displays.
 
 Writing Data
 ~~~~~~~~~~~~


### PR DESCRIPTION
Older LCDs (or LCDs that are based off the HD44870) aren't all made equal.

It appears that some don't run at the reference clock, and as such, they're in a busy state far more often than newer or better ones, which means that, occasionally, subsequent sends are missed. 

I based this off of Adafruit's older library, which included a flat 1 millisecond delay on every send event. From my testing, about 0.5 milliseconds is enough to prevent the issue, but I erred on the higher side at 0.7 milliseconds here. 

From my testing, this fixes #70 which seems to plague only some users on specific hardware.