### PR TITLE
Do not busy wait in compat_mode, make the wait amount tunable

### DIFF
--- a/RPLCD/gpio.py
+++ b/RPLCD/gpio.py
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import namedtuple
+from time import sleep
 
 import RPi.GPIO as GPIO
 
@@ -36,8 +37,6 @@ if sys.version_info.major < 3:
 else:
     from time import perf_counter as now
 
-# Duration to rate-limit calls to _send
-COMPAT_MODE_WAIT_TIME = 0.001
 
 PinConfig = namedtuple('PinConfig', 'rs rw e d0 d1 d2 d3 d4 d5 d6 d7 backlight mode')
 
@@ -49,7 +48,8 @@ class CharLCD(BaseCharLCD):
                        cols=20, rows=4, dotsize=8,
                        charmap='A02',
                        auto_linebreaks=True,
-                       compat_mode=False):
+                       compat_mode=False,
+                       compat_mode_wait_time=0.001):
         """
         Character LCD controller.
 
@@ -97,10 +97,14 @@ class CharLCD(BaseCharLCD):
         :param compat_mode: Whether to run additional checks to support older LCDs
             that may not run at the reference clock (or keep up with it).
         :type compat_mode: bool
+        :param compat_mode_wait_time: Minimum time to pass between sends.
+            if zero, turns off compat_mode  Default: ``0.001`` seconds.
+        :type compat_mode_wait_time: float
 
         """
         # Configure compatibility mode
-        self.compat_mode = compat_mode
+        self.compat_mode = compat_mode and compat_mode_wait_time > 0
+        self.compat_mode_wait_time = compat_mode_wait_time
         if compat_mode:
             self.last_send_event = now()
 
@@ -245,6 +249,8 @@ class CharLCD(BaseCharLCD):
 
     def _wait(self):
         """Rate limit the number of send events."""
-        end = self.last_send_event + COMPAT_MODE_WAIT_TIME
-        while now() < end:
-            pass
+        end = self.last_send_event + self.compat_mode_wait_time
+        sleep_duration = end - now()
+        if sleep_duration > 0:
+            sleep(sleep_duration)
+


### PR DESCRIPTION
Hi, so i added compat mode into the pigpio implementation and made the wait amount tune-able. The waits are not precise now, this can be improved by waiting most of the time using sleep and the rest busy waiting, but, as the amount can be now adjusted, you should be able to get the behavior you want without this trick.

The code is now duplicated, making a single wait function and fields in the lcd module may be preferable. Just ask and I'll do it.

I have another thing ready for a pull request. I made the caching optional as my setup produces too many errors for me to trust it with displaying the text right on the first try.

I have not tested the gpio implementation, but i changed only the wait method slightly with no adverse effects on the pigpio side as far as i can tell.

This is my first time trying to contribute to an open-source project, so criticize everything i do, so I'll learn something new :)