### PR TITLE
Fix pin mapping table formatting

### DIFF
--- a/RPLCD/i2c.py
+++ b/RPLCD/i2c.py
@@ -69,6 +69,7 @@ class CharLCD(BaseCharLCD):
             Pin mapping::
 
             7  | 6  | 5  | 4  | 3  | 2  | 1  | 0
+            -- | -- | -- | -- | -- | -- | -- | --
             D7 | D6 | D5 | D4 | BL | EN | RW | RS
 
 
@@ -92,6 +93,7 @@ class CharLCD(BaseCharLCD):
             Pin mapping::
 
             7  | 6  | 5  | 4  | 3  | 2 | 1  | 0
+            -- | -- | -- | -- | -- | - | -- | - 
             BL | D7 | D6 | D5 | D4 | E | RS | -
 
 


### PR DESCRIPTION
Make the pin mapping work as Markdown tables so it is readable in the generated docs